### PR TITLE
add coreutils to use df "l" option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN set -ex; \
         tzdata \
         unzip \
         nginx \
+	coreutils \
         # forward request and error logs to docker log collector
         && ln -sf /dev/stdout /var/log/nginx/access.log \
         && ln -sf /dev/stderr /var/log/nginx/error.log \


### PR DESCRIPTION
kodbox经常报 `df: unrecognized option: l`，安装coreutils替代busybox的df