### PR TITLE
add 7z in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN set -ex; \
         ffmpeg \
         tzdata \
         unzip \
+	p7zip \
         nginx \
 	coreutils \
         # forward request and error logs to docker log collector

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -95,6 +95,8 @@ if  directory_empty "/var/www/html"; then
   fi
   echo "KODBOX is installing ..."
   rsync $rsync_options --delete /usr/src/kodbox/ /var/www/html/
+  if [ -f /var/www/html/app/sdks/archiveLib/bin/7z_linux ]; then
+    cp /usr/bin/7z /var/www/html/app/sdks/archiveLib/bin/7z_linux
   if [ -n "${KODBOX_ADMIN_USER+x}" ] && [ -n "${KODBOX_ADMIN_PASSWORD+x}" ]; then
     waiting_for_cache
     waiting_for_db


### PR DESCRIPTION
alpine 下无法使用 glibc 编译出的 7z，文件存在但 php/bash 等报不存在
具体可见
https://laysent.com/til/2019-12-02_7zip-bin-in-alpine-docker 

这个PR添加了 alpine 的 p7zip 并拷贝到 kodbox 的安装文件夹下