### PR TITLE
Support for loongarch64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM php:8.2-fpm-alpine3.19
+FROM lcr.loongnix.cn/library/php:8.3-fpm-alpine3.19
 
-# RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
 # entrypoint.sh and dependencies
 RUN set -ex; \
     \
@@ -15,7 +14,6 @@ RUN set -ex; \
         unzip \
         # p7zip \
         nginx \
-        coreutils \
         # forward request and error logs to docker log collector
         && ln -sf /dev/stdout /var/log/nginx/access.log \
         && ln -sf /dev/stderr /var/log/nginx/error.log \
@@ -70,6 +68,8 @@ RUN set -ex; \
         curl-dev \
         imagemagick-dev \
     ; \
+    \
+    ln -sb /bin/busybox /bin/tar; \
     \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
     docker-php-ext-configure intl; \

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   db:
-    image: mariadb:10.6
+    image: lcr.loongnix.cn/library/mariadb:10.5.18
     restart: always
     command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --binlog-format=ROW
     volumes:
@@ -15,7 +15,7 @@ services:
       - db.env
       
   app:
-    image: kodcloud/kodbox
+    image: kodbox
     restart: always
     ports:
       - 80:80                       #左边80是使用端口，可以修改
@@ -31,5 +31,5 @@ services:
       - redis
 
   redis:
-    image: redis:alpine
+    image: lcr.loongnix.cn/library/redis:7.0-alpine
     restart: always


### PR DESCRIPTION
No need to merge.

materials:

- [Loongson official docker repository (API 2.0)](https://lcr.loongnix.cn/search)
- [alpine linux 3.18 (ported by loongson)](https://dev.alpinelinux.org/~loongarch/v3.18/releases/loongarch64/alpine-standard-v3.18.4-loongarch64.iso) (stable)
- [alpine linux 3.19 (ported by loongson)](https://dev.alpinelinux.org/~loongarch/edge-9c13e7/releases/loongarch64/alpine-standard-edge-9c13-loongarch64.iso) (unstable)